### PR TITLE
Fix unparenting (possibly) and errors in click listener.

### DIFF
--- a/Runtime/ArenaClientScene.cs
+++ b/Runtime/ArenaClientScene.cs
@@ -626,24 +626,7 @@ namespace ArenaUnity
                     break;
             }
 
-            // update transform properties, only apply if updated in mqtt message
-            if (isElement(data.position))
-                gobj.transform.localPosition = ArenaUnity.ToUnityPosition(data.position);
-            if (isElement(data.rotation))
-            {
-                // TODO: needed? bool invertY = !((string)data.object_type == "camera");
-                bool invertY = true;
-                if (isElement(data.rotation.w)) // quaternion
-                    gobj.transform.localRotation = ArenaUnity.ToUnityRotationQuat(data.rotation, invertY);
-                else // euler
-                    gobj.transform.localRotation = ArenaUnity.ToUnityRotationEuler(data.rotation, invertY);
-                if (gltfTypeList.Where(x => x.Contains((string)data.object_type)).FirstOrDefault() != null)
-                    gobj.transform.localRotation = ArenaUnity.GltfToUnityRotationQuat(gobj.transform.localRotation);
-            }
-            if (isElement(data.scale))
-                gobj.transform.localScale = ArenaUnity.ToUnityScale(data.scale);
-
-            // data.parent
+            // handle data.parent BEFORE setting transform in case object becomes unparented
             if (parent != null)
             {
                 // establish parent/child relationships
@@ -660,6 +643,12 @@ namespace ArenaUnity
                     childObjs.Add(object_id, gobj);
                 }
             }
+            else {
+                if (gobj.transform.parent != null) {
+                    gobj.transform.SetParent(null);
+                }
+            }
+
             if (parentalQueue.Contains(object_id))
             {
                 // find children awaiting a parent
@@ -677,6 +666,23 @@ namespace ArenaUnity
                 }
                 parentalQueue.Remove(object_id);
             }
+
+            // update transform properties, only apply if updated in mqtt message
+            if (isElement(data.position))
+                gobj.transform.localPosition = ArenaUnity.ToUnityPosition(data.position);
+            if (isElement(data.rotation))
+            {
+                // TODO: needed? bool invertY = !((string)data.object_type == "camera");
+                bool invertY = true;
+                if (isElement(data.rotation.w)) // quaternion
+                    gobj.transform.localRotation = ArenaUnity.ToUnityRotationQuat(data.rotation, invertY);
+                else // euler
+                    gobj.transform.localRotation = ArenaUnity.ToUnityRotationEuler(data.rotation, invertY);
+                if (gltfTypeList.Where(x => x.Contains((string)data.object_type)).FirstOrDefault() != null)
+                    gobj.transform.localRotation = ArenaUnity.GltfToUnityRotationQuat(gobj.transform.localRotation);
+            }
+            if (isElement(data.scale))
+                gobj.transform.localScale = ArenaUnity.ToUnityScale(data.scale);
 
             gobj.transform.hasChanged = false;
 

--- a/Runtime/Components/ArenaClickListener.cs
+++ b/Runtime/Components/ArenaClickListener.cs
@@ -26,6 +26,8 @@ namespace ArenaUnity.Components
         private void Start()
         {
             _camera = Camera.main;
+            if (_camera == null) return;
+
             _arenaCam = _camera.GetComponent<ArenaCamera>();
             if (_arenaCam == null) _arenaCam = _camera.gameObject.AddComponent<ArenaCamera>();
         }
@@ -94,6 +96,8 @@ namespace ArenaUnity.Components
 
         internal void PublishMouseEvent(string eventType)
         {
+            if (_camera == null) return;
+
             RaycastHit hit;
             Ray ray = _camera.ScreenPointToRay(Input.mousePosition);
             Physics.Raycast(ray, out hit);


### PR DESCRIPTION
Fixes:
1. Issue with unparenting an object (setting data.parent=null through MQTT would not actually unset the parent of an object's transform). 
2. Random errors in click listener when Camera.main is null. 